### PR TITLE
Add Google OAuth login with session management

### DIFF
--- a/go_app/auth.go
+++ b/go_app/auth.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+)
+
+var oauthCfg *oauth2.Config
+
+func InitOAuth() {
+	oauthCfg = &oauth2.Config{
+		ClientID:     os.Getenv("GOOGLE_CLIENT_ID"),
+		ClientSecret: os.Getenv("GOOGLE_CLIENT_SECRET"),
+		RedirectURL:  os.Getenv("GOOGLE_REDIRECT_URL"),
+		Scopes:       []string{"openid", "email", "profile"},
+		Endpoint:     google.Endpoint,
+	}
+}
+
+func randomString(n int) (string, error) {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.URLEncoding.EncodeToString(b), nil
+}
+
+func HandleLogin(ctx *gin.Context) {
+	state, err := randomString(16)
+	if err != nil {
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+	ctx.Redirect(http.StatusFound, oauthCfg.AuthCodeURL(state, oauth2.AccessTypeOffline))
+}
+
+func HandleOAuthCallback(ctx *gin.Context) {
+	token, err := oauthCfg.Exchange(ctx, ctx.Query("code"))
+	if err != nil {
+		log.Printf("OAuth token exchange error: %s", err)
+		ctx.Redirect(http.StatusSeeOther, "/login")
+		return
+	}
+
+	resp, err := oauthCfg.Client(ctx, token).Get("https://www.googleapis.com/oauth2/v2/userinfo")
+	if err != nil {
+		log.Printf("Failed to get user info: %s", err)
+		ctx.Redirect(http.StatusSeeOther, "/login")
+		return
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	var userInfo map[string]any
+	json.Unmarshal(body, &userInfo)
+
+	email, _ := userInfo["email"].(string)
+	if email == "" {
+		ctx.Redirect(http.StatusSeeOther, "/login")
+		return
+	}
+
+	sessionID, err := randomString(32)
+	if err != nil {
+		ctx.Status(http.StatusInternalServerError)
+		return
+	}
+
+	cigarDB.Create(&Session{ID: sessionID, Email: email, CreatedAt: time.Now()})
+	ctx.SetCookie("cigarland_session", sessionID, 86400*30, "/", "", false, true)
+	ctx.Redirect(http.StatusSeeOther, "/")
+}
+
+func HandleLogout(ctx *gin.Context) {
+	if cookie, err := ctx.Cookie("cigarland_session"); err == nil {
+		cigarDB.Delete(&Session{}, "id = ?", cookie)
+	}
+	ctx.SetCookie("cigarland_session", "", -1, "/", "", false, true)
+	ctx.Redirect(http.StatusSeeOther, "/login")
+}
+
+func GetCurrentUser(ctx *gin.Context) (string, bool) {
+	sessionID, err := ctx.Cookie("cigarland_session")
+	if err != nil {
+		return "", false
+	}
+	var session Session
+	if cigarDB.Where("id = ?", sessionID).First(&session).Error != nil {
+		return "", false
+	}
+	return session.Email, true
+}
+
+func WithAuth() gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		if _, ok := GetCurrentUser(ctx); !ok {
+			ctx.Redirect(http.StatusSeeOther, "/login")
+			ctx.Abort()
+			return
+		}
+		ctx.Next()
+	}
+}

--- a/www/html/login.html
+++ b/www/html/login.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cigarland — Login</title>
+    <link rel="stylesheet" href="style.css?v=27">
+    <link rel="icon" href="pictures/favicon.ico" type="image/x-icon">
+</head>
+<body>
+    <nav class="top-nav">
+        <ul class="nav-list">
+            <li><a href="./index.html">Cigars</a></li>
+            <li>
+                <label class="switch" title="Toggle dark mode">
+                    <input type="checkbox" id="themeSwitch">
+                    <span class="slider"></span>
+                </label>
+            </li>
+        </ul>
+    </nav>
+
+    <div class="login-form">
+        <h2>Cigarland</h2>
+        <a href="/login" style="display:block; text-decoration:none;">
+            <button type="button">Login with Google</button>
+        </a>
+    </div>
+
+    <script src="js/dark_mode.js?v=1"></script>
+</body>
+</html>


### PR DESCRIPTION
- /login redirects to Google OAuth, /logout clears session
- Sessions stored in PostgreSQL via GORM
- WithAuth middleware protects API routes
- Static login.html page matching existing site style
- Nginx proxies /login, /logout, /auth/ to app
- Google OAuth env vars wired into docker-compose